### PR TITLE
Fix dictionary reference error and handle mixed simplified/traditional Chinese transcripts (issue #123)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests
 gevent
 faster-whisper
 fsspec
+opencc-python-reimplemented

--- a/set.ini
+++ b/set.ini
@@ -17,3 +17,6 @@ temperature=0
 condition_on_previous_text=false
 initial_prompt_zh=
 model_list=tiny,tiny.en,base,base.en,small,small.en,medium,medium.en,large-v1,large-v2,large-v3,large-v3-turbo,distil-whisper-small.en,distil-whisper-medium.en,distil-whisper-large-v2,distil-whisper-large-v3,zh-plus/faster-whisper-large-v2-japanese-5k-steps
+
+;Use only OpenCC configs: s2t (Simplified→Traditional) and t2s (Traditional→Simplified)
+opencc = t2s

--- a/start.py
+++ b/start.py
@@ -173,6 +173,8 @@ def shibie():
                 if not text or re.match(r'^[，。、？‘’“”；：（｛｝【】）:;"\'\s \d`!@#$%^&*()_+=.,?/\\-]*$', text) or len(
                         text) <= 1:
                     continue
+                if cfg.cc is not None:
+                    text=cfg.cc.convert(text)
                 if data_type == 'json':
                     # 原语言字幕
                     raw_subtitles.append(

--- a/start.py
+++ b/start.py
@@ -207,7 +207,7 @@ def process():
     data_type = request.form.get("data_type")
     wav_file = os.path.join(cfg.TMP_DIR, wav_name)
     if not os.path.exists(wav_file):
-        return jsonify({"code": 1, "msg": f"{wav_file} {cfg.langlist['lang5']}"})
+        return jsonify({"code": 1, "msg": f"{wav_file} {cfg.transobj['lang5']}"})
 
     key=f'{wav_name}{model}{language}{data_type}'
     #重设结果为none

--- a/stslib/cfg.py
+++ b/stslib/cfg.py
@@ -4,6 +4,7 @@ import sys
 import torch
 import re
 ROOT_DIR = os.getcwd()
+from opencc import OpenCC
 
 def parse_ini(file=os.path.join(ROOT_DIR,'set.ini')):
     
@@ -22,8 +23,8 @@ def parse_ini(file=os.path.join(ROOT_DIR,'set.ini')):
         "vad":True,
         "temperature":0,
         "condition_on_previous_text":False,
+        'opencc': 't2s',
         "initial_prompt_zh":"转录为中文简体。"
-
     }
     if not os.path.exists(file):
         return sets
@@ -44,9 +45,17 @@ def parse_ini(file=os.path.join(ROOT_DIR,'set.ini')):
                 sets[line[0]]=line[1].split(',')
             elif line[1]:
                 sets[line[0]]=str(line[1]).lower()
+    if sets['opencc'] == 's2t':
+        sets["initial_prompt_zh"] = "转录为中文繁体。"
     return sets
 
 sets=parse_ini()
+
+trans=sets.get('opencc')
+if trans in ('s2t','t2s'):
+    cc = OpenCC(trans)
+else :
+    cc = None
 
 web_address=sets.get('web_address')
 LANG=sets.get('lang','zh')


### PR DESCRIPTION
Fix dictionary reference error and handle mixed simplified/traditional Chinese transcripts 

## Summary

1. **Dictionary reference error**  
A mis-referenced configuration key caused unexpected errors during transcription.  
﻿
2. **The following issues reported in #123 have been resolved**  
Mixed Simplified and Traditional Chinese transcripts. The transcription output could contain a mixture of Simplified and Traditional characters.  
An optional OpenCC-based normalization step has been added to ensure consistent script output
(Simplified or Traditional), depending on the user's configuration.
﻿
Closes #123.